### PR TITLE
Add cross-env & update lock version 10.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
-    "auth0-lock": "10.6.1",
+    "auth0-lock": "10.3.0",
     "breakpoint-sass": "2.7.0",
     "classnames": "2.2.5",
     "cross-env": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "6.3.1"
   },
   "scripts": {
-    "build:client": "NODE_ENV=production webpack",
+    "build:client": "cross-env NODE_ENV=production webpack",
     "build:src": "babel src -d dist",
     "build": "npm run build:client && npm run build:src",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
@@ -66,9 +66,10 @@
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
-    "auth0-lock": "10.1.0",
+    "auth0-lock": "10.6.1",
     "breakpoint-sass": "2.7.0",
     "classnames": "2.2.5",
+    "cross-env": "^3.1.3",
     "dotenv": "2.0.0",
     "good": "7.0.1",
     "good-console": "6.1.2",


### PR DESCRIPTION
Updated project to have cross-env.  Project now builds on windows. Updated to lock version 10.3.0.  Attempted to update to lock 10.6.1 to test new custom social identities available in lock 10.5.1+, but looks like auth-lock 10.4.0 introduced a change which produces this error:

Uncaught TypeError: Cannot use 'in' operator to search for 'window' in undefined(…)

Didn't dig into potential resolution, 10.3.0 is the highest which still functions